### PR TITLE
Asyncio and Midi Off!

### DIFF
--- a/eventlist.py
+++ b/eventlist.py
@@ -29,8 +29,14 @@ def list():
           break
 
     #list events
-    for i in range(1,max):
+    for i in range(1,max+1):
         getGamepad(i)
+
+
+if __name__ == "__main__":
+    list()
+    del dev
+    quit()
 
 
 #exit

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 print("this is a first draft. Midi off has not been sent. Only play terminal sounds or have a midi panic ready")
 
 #import
-import evdev, rtmidi, time, random
+import evdev, rtmidi, time, random, asyncio
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import eventlist, vel
@@ -17,6 +17,9 @@ gamepad = ""
 longPrompt = True
 
 #global configs
+#note length (seconds)
+defaultLength = 1
+
 #velocity defaults
 defaultMax = 127
 defaultMin = 10
@@ -27,7 +30,7 @@ defaultSteps = 7
 smooth = True
 #higher will favor the new velocity. >1 will accent changes in velocity. <0 will crash
 smoothWeight = 0.5
-#final velocity = velocuty + plus or minus up to velrandomize
+#final velocity = velocity + plus or minus up to velrandomize
 velRandomize = 3
 
 #velocity bounds
@@ -55,25 +58,72 @@ def getGamepad(test):
         run = False
 
 
+#note off-inator class
+lsActiveNotes = []
+class noteKiller(object):
+    def __init__(self):
+        self.length = 0
+        self.note = 1
+        self.channel = 1
+        self.start = 0
+        self.active = False
+        #add self to list
+        global lsActiveNotes
+        lsActiveNotes.append(self)
+
+
+    def set(self, length, note, channel=1):
+        #write down the time
+        self.length = length
+        self.note = note
+        self.channel = channel
+        self.start = time.time()
+        self.active = True
+        print(str(self.channel) + " set!")
+
+    def tryEnd(self, velocity=0):
+        #if self is too old, send off command and remove from list
+        if time.time() - self.start > self.length and self.active == True:
+            #remove note
+            note_off = [127+self.channel, self.note, 1]
+            midiout.send_message(note_off)
+            self.active = False
+            print("killed " + str(self.channel))
+            #remove list
+            #global lsActiveNotes
+            #lsActiveNotes.remove(self)
+
+
+
 #define class for each physical button
+
+lsControl = []
 class Control(object):
-    def __init__(self, code, type, message="debug", note="1", channel=1, velInfo=[defaultSteps, defaultMin, defaultMax, defaultMode]):
+    def __init__(self, code, type, message="debug", note=1, channel=1, length=defaultLength, velInfo=[defaultSteps, defaultMin, defaultMax, defaultMode]):
         #type 0 = dummy, 1 = midi, 2 = controls
         self.code = code
         self.type = type
         self.message = message
         self.note = note
+        self.length = length
         self.channel  = channel
         self.velInfo = velInfo
+        self.noteKiller = noteKiller()
 
-        self.oldVel = 0
+        self.oldVel = vel.curve(self.velInfo[0]/2, self.velInfo[0], self.velInfo[1], self.velInfo[2], self.velInfo[3])
+
+        global lsControl
+        lsControl.append(self)
+
 
     #input.payload is intended to be run when the button is pressed. depends on button type
-    def payload(self, val=0):
+    def payload(self, val=0, offVel=0):
         #midi - play slef.note
         if self.type == 1:
             #if the pressure isnt 0 play note
             if val != 0:
+
+                #deterimin velocity
                 velocity = vel.curve(val, self.velInfo[0], self.velInfo[1], self.velInfo[2], self.velInfo[3])
 
                 #this if statement avoids crashing because of an "empty range". I think randomrange(0, 0) should always return zero but oh well.
@@ -86,10 +136,20 @@ class Control(object):
                 #keep in range
                 velocity = vel.trunc(velocity, velAbsMin, velAbsMax)
 
+
+                #end previos note
+                note_off = [(127+self.channel), self.note, offVel]
+                midiout.send_message(note_off)
+
+                #actually play the note
                 print(self.message + str(val) + " - " + str(velocity))
                 note_on = [(143+self.channel), self.note, velocity]
                 midiout.send_message(note_on)
+                # note velocty for smoothing
                 self.oldVel = velocity
+                # set note to be turned off
+                self.noteKiller.set(self.length, self.note, self.channel)
+
             else:
                 pass
         elif self.type == 2:
@@ -102,18 +162,35 @@ class Control(object):
         else:
             print(self.message + str(val))
 
+    def EndNote(self):
+        note_off = [(127+self.channel), self.note, offVel]
+        midiout.send_message(note_off)
+
 
 # define all the notes
 
 lightCurve = [defaultSteps, 40, 200, defaultMode]
+heavyCurve = [defaultSteps, -40, 116, defaultMode]
+
+
 
 #name = Control(device code, 1 (midi mode), "message", midi note, midi channe, velocity curve info)
+
+#avldrum kit
 PadRed = Control(16, 1, "red", 38, 1, lightCurve)
 PadBlue = Control(17, 1, "blue", 40, 1, lightCurve)
 PadGreen = Control(18, 1, "green", 45, 1, lightCurve)
 PadYellow = Control(20, 1, "yello", 42, 1)
-PadOrange = Control(21, 1, "orange", 61, 1)
+PadOrange = Control(21, 1, "orange", 60, 1, heavyCurve)
 Pedal = Control(22, 1, "pedal", 36, 1, lightCurve)
+
+#channel mode
+#PadRed = Control(16, 1, "red", 64, 1, defaultLength, lightCurve)
+#PadBlue = Control(17, 1, "blue", 64, 2, defaultLength, lightCurve)
+#PadGreen = Control(18, 1, "green", 64, 3, defaultLength, lightCurve)
+#PadYellow = Control(20, 1, "yello", 64, 4)
+#PadOrange = Control(21, 1, "orange", 64, 5, defaultLength, heavyCurve)
+#Pedal = Control(22, 1, "pedal", 64, 6, defaultLength, lightCurve)
 
 StickX = Control(0, 2, "StickX", 1)
 StickY = Control(1, 2, "StickY", 2)
@@ -121,9 +198,40 @@ StickY = Control(1, 2, "StickY", 2)
 Minus = Control(314, 3, "Minus Button", 1)
 Plus = Control(315, 3, "Plus Button", 2)
 
-lsControl = [PadGreen, PadBlue, PadRed, PadYellow, PadOrange, Pedal, StickX, StickY, Minus, Plus]
 
 
+#Player
+async def player():
+    #for event in gamepad.read_loop():
+    async for event in gamepad.async_read_loop():
+        #read gamepad
+        #if event.type == evdev.ecodes.EV_KEY:
+            #print(event)
+        #elif event.type == evdev.ecodes.EV_ABS:
+            #pass
+
+        #if the event has a control tied to it, run that controls payload (play it's note)
+        for i in lsControl:
+            #await asyncio.sleep(0)
+            if event.code == i.code:
+                i.payload(event.value)
+        await asyncio.sleep(0)
+
+#Killer
+killerRun = True
+async def killer():
+    while killerRun == True:
+        #print("looped!")
+        await asyncio.sleep(0)
+        for i in lsActiveNotes:
+            i.tryEnd()
+
+#Main
+async def main():
+    await asyncio.gather(
+        killer(),
+        player()
+    )
 
 #START
 
@@ -146,16 +254,15 @@ while run == True:
         getGamepad(num)
 
 #main
-for event in gamepad.read_loop():
-    #read gamepad
-    if event.type == evdev.ecodes.EV_KEY:
-        print(event)
-    elif event.type == evdev.ecodes.EV_ABS:
-        #if event.value !=0:
-        for i in lsControl:
-            if event.code == i.code:
-                i.payload(event.value)
+asyncio.run(main())
 
+
+
+
+
+#close
+for i in lsControl:
+    i.EndNote()
 
 del gamepad
 del midiout


### PR DESCRIPTION
after many hours of only slightly obsessive thought, I have reached a solution to midi off. Asyncio is a python modal for running asynchronous tasks, such as stopping and starting notes at different times. The previous main loop now runs in an async function called player. A new function called killer continuously looks for notes that are too old and stops them. each control object now has a new self.notekiller which is a new object class. it corresponds to a playing note and if it's too old turns it off.

controls can now be defined with a length parameter for how long the not will be played. a new global variable can be used to set the default length.

also includes a handful of small fixes:

- eventlist will now list if run by itself
- eventlist used to not list all devices
- commented out but there is a preconfiguration for each drum playing note 64 but on different channels